### PR TITLE
Fixed output folder bug when output variable is changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ This bash script tests for sticky keys and utilman  backdoors. The script will c
 ## Prerequisites
 
 1. Linux host running an X server
-2. The following packages: xdotool imagemagick rdesktop
-    3. Debian/Ubuntu/Kali install: `apt-get install xdotool imagemagick rdesktop`
+2. The following packages: xdotool imagemagick rdesktop bc
+    3. Debian/Ubuntu/Kali install: `apt-get install xdotool imagemagick rdesktop bc`
 3. Screen cannot be locked during this process or all of the screenshots will turn out black
 
 ## Usage

--- a/stickyKeysHunter.sh
+++ b/stickyKeysHunter.sh
@@ -136,7 +136,7 @@ if [ ! -d "${output}" ]; then
     mkdir "${output}"
 fi
 
-afterScreenshot="output/${host}.png"
+afterScreenshot="${output}/${host}.png"
 screenshot "${afterScreenshot}" "${window}"
 
 # Close the rdesktop window


### PR DESCRIPTION
When changing the 'output' variable, the script no longer saved screenshots. Found that the output folder was hard coded and changed it to a variable.
